### PR TITLE
Add filter to allow normalisation of term name and slug

### DIFF
--- a/adapters/wpcom-vip.php
+++ b/adapters/wpcom-vip.php
@@ -153,3 +153,18 @@ function vip_es_meta_value_tolower( $meta_value, $meta_key, $meta_compare, $meta
 	return $meta_value;
 }
 add_filter( 'es_meta_query_meta_value', 'vip_es_meta_value_tolower', 10, 4 );
+
+/**
+ * Normalise term name to lowercase as we are mapping that agains raw_lc field.
+ *
+ * @param $term string|mixed Term's name which should be normalised to lowercase.
+ * @param $taxonomy string Taxonomy of the term.
+ * @return mixed If $term is a string, lowercased string is returned. Otherwise original value is return unchanged.
+ */
+function vip_es_term_name_slug_tolower( $term, $taxonomy ) {
+	if ( ! is_string( $term ) || empty( $term ) ) {
+		return $term;
+	}
+	return strtolower( $term );
+}
+add_filter( 'es_tax_query_term_name', 'vip_es_term_name_slug_tolower', 10, 2 );

--- a/class-es-wp-tax-query.php
+++ b/class-es-wp-tax-query.php
@@ -168,6 +168,16 @@ class ES_WP_Tax_Query extends WP_Tax_Query {
 					 * context is 'db'.
 					 */
 					$term = sanitize_term_field( $clause['field'], $term, 0, $clause['taxonomy'], 'db' );
+					
+					/**
+					 * Allow adapters to normalize term value (like `strtolower` if mapping to `raw_lc`).
+					 *
+					 * The dynamic portion of the filter name, `$clause['field']`, refers to the term field. 
+					 *
+					 * @param mixed	$term Term's slug or name sanitised using `sanitize_term_field` function for db context.
+					 * @param string $taxonomy Term's taxonomy slug.
+					 */
+					$term = apply_filters( "es_tax_query_term_{$clause['field']}", $term, $clause['taxonomy'] );
 				}
 				$current_filter = call_user_func( $terms_method, $this->es_query->tax_map( $clause['taxonomy'], 'term_' . $clause['field'] ), $clause['terms'] );
 				break;


### PR DESCRIPTION
As the latest version of the plugin is using `sanitize_term_field` instead of the e `sanitize_title_for_query` the name and slug are no longer being transformed to lowercase (`sanitize_title_for_query` does that while `sanitize_term_field` does not).

This patch is adding a new filter, similar to `es_meta_query_meta_value` one which is dealing with similar issue, in order to allow adapters to fine control the normalisation. As not all adapters are necessary mapping post name or slug to lowecase field, this approach feels better than hardcoding `strtolower` to the plugin itself.